### PR TITLE
fix: 'test_exiftool()'s 'system2()' version call

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -161,7 +161,7 @@ test_exiftool <- function(command, quiet = TRUE) {
                                       silent = TRUE)))
     if (command_works) {
         ## check that version is a numeric value like 10.96
-        ver_string <- paste(system2(command, args = args, stderr = FALSE),
+        ver_string <- paste(system2(command, args = args, stdout = TRUE, stderr = FALSE),
                             collapse = "\n")
         ver_number <- suppressWarnings(as.numeric(ver_string))
         return(!is.na(ver_number))


### PR DESCRIPTION
* Now: `system2(command, args = args, stdout = TRUE, stderr = FALSE)` returns version number as intended.
* Previous: `system2(command, args = args, stderr = FALSE)` returns `0` (since command didn't fail) and prints out version number even if `quiet = TRUE`. Note `as.numeric(0)` still successfully casts as a numeric so wasn't throwing an error...
* Not entirely sure why there is a `paste( collapse = "\n")` but I assume you had a reason (for Windows?)