### PR TITLE
fix: Use 'R_user_dir()' instead of package directory as default for 'install_exiftool()'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/_site/*
 /README.html
 /inst/exiftool/win_exe/*
 /docs/
+*.swp

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ URL: https://github.com/JoshOBrien/exiftoolr#readme
 BugReports: https://github.com/JoshOBrien/exiftoolr/issues
 SystemRequirements: Perl
 Imports: 
+    backports,
     curl,
     jsonlite,
     zip,

--- a/R/hooks.R
+++ b/R/hooks.R
@@ -1,0 +1,3 @@
+.onLoad <- function(libname, pkgname) {
+    backports::import(pkgname, "R_user_dir", force = TRUE)
+}

--- a/R/install.R
+++ b/R/install.R
@@ -54,7 +54,10 @@ install_exiftool <- function(install_location = NULL,
     ##---------------------------##
     if (is.null(install_location)) {
         ## Default install location
-        install_location <- system.file("exiftool", package = "exiftoolr")
+        install_location <- R_user_dir("exiftoolr")
+        if (!dir.exists(install_location)) {
+            dir.create(install_location, recursive = TRUE)
+        }
     }
 
     ## Find writable locations


### PR DESCRIPTION
* Use `{backports}` version of `R_user_dir("exiftoolr")` instead of `system.file("exiftool", package = "exiftoolr")` as default for `install_exiftool()`.
* The directory and the "R" directory above aren't automatically created by R so we need to use a `dir.create(recursive = TRUE)` to create them if necessary.
* We always use the `{backports}` version even for later versions of R when it exists in `{tools}`. See https://github.com/r-lib/backports for more complicated arrangements.
* Technically this requires users have R >= 3.0.0 (instead of R >= 4.0.0). Not sure who is still lesser versions of R...
* Confirm that this causes `install_exiftool()` to now work on my computer (whose R libraries are root and not user-writable).

closes #10