### PR TITLE
fix: Newlines in 'exif_call()'s 'args'

### DIFF
--- a/R/exif_read.R
+++ b/R/exif_read.R
@@ -273,10 +273,13 @@ exif_version <- function(quiet = TRUE) {
 
 ## private helper command to generate call to exiftool
 construct_argfile <- function(args, path) {
+    if (any(gl <- grepl("\n", args))) {
+        args <- ifelse(gl,
+                       paste0("#[CSTR]", gsub("\n", "\\\\n", args)),
+                       args)
+    }
     all_args <- c(args, path)
     tmpfile <- tempfile("args.cmd")
     writeLines(all_args, tmpfile, sep="\n")
     tmpfile
 }
-
-


### PR DESCRIPTION
* Fix by finding out which `args` has newlines, escape them, and prepend those lines with `#[CSTR]`
* The `#[CSTR]` newline feature in `exiftool` args files is documented here: https://exiftool.org/faq.html#Q21
* Note `grepl("\n", "boo\nbar")` is `TRUE` but `grepl("\n", "boo\\nbar")` is `FALSE`.  In particular if a user of `{exiftoolr}` has already manually done this correction then it shouldn't happen a second time (and break things).

closes #14